### PR TITLE
fix 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to AudioSeal are documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.1.3] - 2024-06-24
+
+- Update scripts to new training code
+- Fix bugs in loading custom fine-tuned model (https://github.com/facebookresearch/audioseal/issues/37)
+
 ## [0.1.3] - 2024-04-30
 
 - Fix bug in getting the watermark with non-empty message created in CPU, while the model is loaded in CUDA

--- a/src/audioseal/builder.py
+++ b/src/audioseal/builder.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import Any, Dict, List, Optional
 
 from omegaconf import DictConfig, OmegaConf
 from torch import device, dtype
@@ -55,7 +55,7 @@ class DecoderConfig:
 
 @dataclass
 class DetectorConfig:
-    output_dim: int
+    output_dim: int = 32
 
 
 @dataclass
@@ -69,7 +69,7 @@ class AudioSealWMConfig:
 class AudioSealDetectorConfig:
     nbits: int
     seanet: SEANetConfig
-    detector: DetectorConfig
+    detector: DetectorConfig = field(default_factory=lambda: DetectorConfig())
 
 
 def as_dict(obj: Any) -> Dict[str, Any]:

--- a/src/audioseal/models.py
+++ b/src/audioseal/models.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("Audioseal")
 COMPATIBLE_WARNING = """
 AudioSeal is designed to work at a sample rate 16khz.
 Implicit sampling rate usage is deprecated and will be removed in future version.
-To remove this warning please add this argument to the function call: 
+To remove this warning please add this argument to the function call:
 sample_rate = your_sample_rate
 """
 
@@ -111,7 +111,9 @@ class AudioSealWM(torch.nn.Module):
         if self.msg_processor is not None:
             if message is None:
                 if self.message is None:
-                    message = torch.randint(0, 2, (x.shape[0], self.msg_processor.nbits), device=x.device)
+                    message = torch.randint(
+                        0, 2, (x.shape[0], self.msg_processor.nbits), device=x.device
+                    )
                 else:
                     message = self.message.to(device=x.device)
             else:


### PR DESCRIPTION
## Why ?

fixes #37 

The PR fixes the renaming issues in checkpoint compilation script.

## Test plan

1. Train a  new dummy model using AudioCraft:
```shell

git clone git@github.com:facebookresearch/audiocraft.git
cd audiocraft
python -m pip install -e ".[wm]"

AUDIOCRAFT_DORA_DIR="/tmp/wm_${USER}" \
    dora run device=cpu dataset.num_workers=0 optim.epochs=1 \
    dataset.train.num_samples=10 \
    dataset.valid.num_samples=10 \
    dataset.evaluate.num_samples=10 \
    dataset.generate.num_samples=10 \
    solver=watermark/robustness \
    checkpoint.save_last=true \
    dset=audio/example
```
/tmp/wm_${USER}/xps/SOME_HASH_CODE/checkpoint.th

You should see the output such as: 

2. Generate the checkpoints in audioseal-friendly format:
```
cd [AudioSeal code directory]
python src/scripts/checkpoints.py /tmp/wm_${USER}/xps/SOME_HASH_CODE/checkpoint.th OUTPUT_DIR
```

3. Try load the checkpoints using AudioSeal API:
```python
from audioseal import AudioSeal
generator = AudioSeal.load_generator("[OUTPUT_DIR/checkpoint_generator_base.pth", nbits=16)

detector = AudioSeal.load_detector("[OUTPUT_DIR/checkpoint_detector_base.pth", nbits=16)
```