### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
   numpy
   omegaconf
   julius
-  torch>=1.13.0
+  torch>=1.13.0,<=2.1.0


### PR DESCRIPTION
  ### **Why?**  
In recent versions of PyTorch, model checkpoints cannot be loaded properly. Additionally, the `audioseal/src/scripts/checkpoints.py` script fails to convert checkpoints correctly. This issue prevents the proper initialization of model weights for both the generator and detector.  

### **How?**  
To resolve this issue, I downgraded PyTorch to version **2.1.0**, which ensures compatibility with `torch.load` for loading and converting checkpoints. This resolves errors related to the `weights_only` parameter in `torch.load`, as referenced in the [PyTorch documentation](https://pytorch.org/docs/stable/generated/torch.load.html)

### **Test Plan**  
I verified the fix by:  
1. Running `audioseal/src/scripts/checkpoints.py` to ensure successful checkpoint conversion.  
2. Loading the model weights using:  
   - `AudioSeal.load_generator()`  
   - `AudioSeal.load_detector()`  

After applying this fix, both the checkpoint conversion and model weight loading work as expected.  

