### PR TITLE
Add model card for llama4 detector

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/src/audioseal/cards/llama4_detector_16bits.yaml
+++ b/src/audioseal/cards/llama4_detector_16bits.yaml
@@ -1,0 +1,33 @@
+# @package __global__
+
+name: audioseal_detector_16bits
+model_type: seanet
+checkpoint: "https://huggingface.co/facebook/audioseal/resolve/main/detector_9e54da39.pth"
+nbits: 16
+seanet:
+  activation: ELU
+  activation_params:
+    alpha: 1.0
+  causal: true
+  channels: 1
+  compress: 2
+  dilation_base: 2
+  dimension: 128
+  disable_norm_outer_blocks: 0
+  kernel_size: 7
+  last_kernel_size: 7
+  lstm: 2
+  n_filters: 32
+  n_residual_layers: 1
+  norm: weight_norm
+  norm_params: {}
+  pad_mode: constant
+  ratios:
+    - 8
+    - 5
+    - 4
+    - 2
+  residual_kernel_size: 3
+  true_skip: true
+detector:
+  output_dim: 32

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -59,7 +59,9 @@ def _get_cache_dir(env_names: List[str]):
     return cache_dir
 
 
-def _safe_load_checkpoint(model_path: Union[str, Path], device: Union[str, torch.device] = "cpu"):
+def _safe_load_checkpoint(
+    model_path: Union[str, Path], device: Union[str, torch.device] = "cpu"
+):
     try:
         ckpt = torch.load(model_path, map_location=device, weights_only=False)
     except pickle.UnpicklingError as _:
@@ -70,6 +72,7 @@ def _safe_load_checkpoint(model_path: Union[str, Path], device: Union[str, torch
         torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig])
         ckpt = torch.load(model_path, map_location=device, weights_only=False)
     return ckpt
+
 
 def load_model_checkpoint(
     model_path: Union[Path, str],
@@ -89,16 +92,16 @@ def load_model_checkpoint(
             str(model_path), model_dir=cache_dir, map_location=device, file_name=hash_
         )
     elif str(model_path).startswith("facebook/audioseal/"):
-        hf_filename = str(model_path)[len("facebook/audioseal/"):]
+        hf_filename = str(model_path)[len("facebook/audioseal/") :]
 
         try:
             from huggingface_hub import hf_hub_download
-        except ModuleNotFoundError:
-            print(
+        except ModuleNotFoundError as ex:
+            raise ModelLoadError(
                 f"The model path {model_path} seems to be a direct HF path, "
                 "but you do not install Huggingface_hub. Install with for example "
                 "`pip install huggingface_hub` to use this feature."
-            )
+            ) from ex
         file = hf_hub_download(
             repo_id="facebook/audioseal",
             filename=hf_filename,
@@ -190,7 +193,7 @@ class AudioSeal:
 
         # remove attributes not related to the model_type
         result_config = {}
-        assert config, f"Empty config"
+        assert config, "Empty config"
         for field in fields(config_type):
             if field.name in config:
                 result_config[field.name] = config[field.name]

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -265,7 +265,7 @@ class AudioSeal:
         )
 
         model = create_generator(config)
-        model.load_state_dict(checkpoint)
+        _update_state_dict(model, checkpoint)
         return model
 
     @staticmethod
@@ -279,5 +279,5 @@ class AudioSeal:
             nbits=nbits,
         )
         model = create_detector(config)
-        model.load_state_dict(checkpoint)
+        _update_state_dict(model, checkpoint)
         return model

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,9 @@ def test_detector(example_audio):
     watermarked_audio = audio + watermark
 
     detector = AudioSeal.load_detector(("audioseal_detector_16bits"))
-    result, message = detector.detect_watermark(watermarked_audio, sample_rate=sr)  # noqa
+    result, message = detector.detect_watermark(
+        watermarked_audio, sample_rate=sr
+    )  # noqa
 
     # Due to non-deterministic decoding, messages are not always the same as message
     print(f"\nOriginal message: {secret_message}")
@@ -54,10 +56,21 @@ def test_detector(example_audio):
     assert result < 0.5
 
 
-def test_loading_from_hf(example_audio):
-    audio, sr = example_audio
+def test_loading_from_hf():
+    generator = AudioSeal.load_generator(
+        "facebook/audioseal/generator_base.pth", nbits=16
+    )
 
-    generator = AudioSeal.load_generator("facebook/audioseal/generator_base.pth", nbits=16)
-    detector = AudioSeal.load_detector("facebook/audioseal/detector_base.pth", nbits=16)
+    assert isinstance(generator, AudioSealWM)
 
-    assert isinstance(generator, AudioSealWM) and isinstance(detector, AudioSealDetector)
+
+@pytest.mark.parametrize(
+    "detector_name", ["facebook/audioseal/detector_base.pth", "llama4_detector_16bits"]
+)
+def test_loading_detectors(detector_name):
+    if detector_name.endswith(".pth"):
+        detector = AudioSeal.load_detector(detector_name, nbits=16)
+    else:
+        detector = AudioSeal.load_detector(detector_name)
+
+    assert isinstance(detector, AudioSealDetector)


### PR DESCRIPTION
- Add a new model card for a new detector
- Fix issues when loading new detector on a very old torch (1.13.0) to maintain the promise of AudioSeal maximum compatibility (torch 1.13.0 - torch 2.x)