### PR TITLE
Fix loading model in Pytorch 2.6+

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -26,7 +26,7 @@ jobs:
           cache: "pip"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip 
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Lint with flake8

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.8"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -48,7 +48,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -48,9 +48,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -72,9 +72,9 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -73,7 +73,7 @@ def load_model_checkpoint(
     device: Union[str, torch.device] = "cpu",
 ):
     if Path(model_path).is_file():
-        return torch.load(model_path, map_location=device)
+        return torch.load(model_path, map_location=device, weights_only=False)
 
     cache_dir = _get_cache_dir(
         ["AUDIOSEAL_CACHE_DIR", "AUDIOCRAFT_CACHE_DIR", "XDG_CACHE_HOME"]

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -75,14 +75,15 @@ def load_model_checkpoint(
 ):
     if Path(model_path).is_file():
         try:
-            return torch.load(model_path, map_location=device, weights_only=False)
+            ckpt = torch.load(model_path, map_location=device, weights_only=False)
         except pickle.UnpicklingError as _:
             # This happens in torch 2.6+ . We make a quick hack to allow omegaconf DictConfig
             # to be passed as a global
             import omegaconf
-            
-            with torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig]):
-                return torch.load(model_path, map_location=device, weights_only=False)
+
+            torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig])
+            ckpt = torch.load(model_path, map_location=device, weights_only=False)
+        return ckpt
 
     cache_dir = _get_cache_dir(
         ["AUDIOSEAL_CACHE_DIR", "AUDIOCRAFT_CACHE_DIR", "XDG_CACHE_HOME"]
@@ -95,7 +96,7 @@ def load_model_checkpoint(
             str(model_path), model_dir=cache_dir, map_location=device, file_name=hash_
         )
     elif str(model_path).startswith("facebook/audioseal/"):
-        hf_filename = str(model_path)[len("facebook/audioseal/") :]
+        hf_filename = str(model_path)[len("facebook/audioseal/"):]
 
         try:
             from huggingface_hub import hf_hub_download

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -6,33 +6,20 @@
 
 
 import os
+import pickle
 from dataclasses import fields
 from hashlib import sha1
 from pathlib import Path
-from typing import (  # type: ignore[attr-defined]
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import (Any, Dict, List, Optional,  # type: ignore[attr-defined]
+                    Tuple, Type, TypeVar, Union, cast)
 from urllib.parse import urlparse  # noqa: F401
 
 import torch
 from omegaconf import DictConfig, OmegaConf
-import pickle
 
 import audioseal
-from audioseal.builder import (
-    AudioSealDetectorConfig,
-    AudioSealWMConfig,
-    create_detector,
-    create_generator,
-)
+from audioseal.builder import (AudioSealDetectorConfig, AudioSealWMConfig,
+                               create_detector, create_generator)
 from audioseal.models import AudioSealDetector, AudioSealWM
 
 AudioSealT = TypeVar("AudioSealT", AudioSealWMConfig, AudioSealDetectorConfig)

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -56,21 +56,24 @@ def _get_cache_dir(env_names: List[str]):
     return cache_dir
 
 
+def _safe_load_checkpoint(model_path: Union[str, Path], device: Union[str, torch.device] = "cpu"):
+    try:
+        ckpt = torch.load(model_path, map_location=device, weights_only=False)
+    except pickle.UnpicklingError as _:
+        # This happens in torch 2.6+ . We make a quick hack to allow omegaconf DictConfig
+        # to be passed as a global
+        import omegaconf
+
+        torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig])
+        ckpt = torch.load(model_path, map_location=device, weights_only=False)
+    return ckpt
+
 def load_model_checkpoint(
     model_path: Union[Path, str],
     device: Union[str, torch.device] = "cpu",
 ):
     if Path(model_path).is_file():
-        try:
-            ckpt = torch.load(model_path, map_location=device, weights_only=False)
-        except pickle.UnpicklingError as _:
-            # This happens in torch 2.6+ . We make a quick hack to allow omegaconf DictConfig
-            # to be passed as a global
-            import omegaconf
-
-            torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig])
-            ckpt = torch.load(model_path, map_location=device, weights_only=False)
-        return ckpt
+        return _safe_load_checkpoint(model_path, device=device)
 
     cache_dir = _get_cache_dir(
         ["AUDIOSEAL_CACHE_DIR", "AUDIOCRAFT_CACHE_DIR", "XDG_CACHE_HOME"]
@@ -100,7 +103,7 @@ def load_model_checkpoint(
             library_name="audioseal",
             library_version=audioseal.__version__,
         )
-        return torch.load(file, map_location=device)
+        return _safe_load_checkpoint(file, device=device)
     else:
         raise ModelLoadError(f"Path or uri {model_path} is unknown or does not exist")
 

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -10,17 +10,7 @@ import pickle
 from dataclasses import fields
 from hashlib import sha1
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import urlparse  # noqa: F401
 
 import torch

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -10,16 +10,29 @@ import pickle
 from dataclasses import fields
 from hashlib import sha1
 from pathlib import Path
-from typing import (Any, Dict, List, Optional,  # type: ignore[attr-defined]
-                    Tuple, Type, TypeVar, Union, cast)
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse  # noqa: F401
 
 import torch
 from omegaconf import DictConfig, OmegaConf
 
 import audioseal
-from audioseal.builder import (AudioSealDetectorConfig, AudioSealWMConfig,
-                               create_detector, create_generator)
+from audioseal.builder import (
+    AudioSealDetectorConfig,
+    AudioSealWMConfig,
+    create_detector,
+    create_generator,
+)
 from audioseal.models import AudioSealDetector, AudioSealWM
 
 AudioSealT = TypeVar("AudioSealT", AudioSealWMConfig, AudioSealDetectorConfig)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,10 +7,10 @@
 
 import urllib
 
-import pytest
 import torch
-import torchaudio
 
+import pytest
+import torchaudio
 from audioseal import AudioSeal
 from audioseal.models import AudioSealDetector, AudioSealWM
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,10 +7,10 @@
 
 import urllib
 
-import torch
-
 import pytest
+import torch
 import torchaudio
+
 from audioseal import AudioSeal
 from audioseal.models import AudioSealDetector, AudioSealWM
 


### PR DESCRIPTION
Starting PyTorch 2.6, there are some changes in loading model https://pytorch.org/blog/pytorch2-6/ . This affects loading the old watermarking checkpoint.