### PR TITLE
Port internal fix to 0.1.8

### DIFF
--- a/src/audioseal/__init__.py
+++ b/src/audioseal/__init__.py
@@ -13,7 +13,7 @@ detector.
 
 """
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 
 from audioseal import builder

--- a/src/audioseal/loader.py
+++ b/src/audioseal/loader.py
@@ -21,6 +21,8 @@ import audioseal
 from audioseal.builder import (
     AudioSealDetectorConfig,
     AudioSealWMConfig,
+    DataType,
+    Device,
     create_detector,
     create_generator,
 )
@@ -293,6 +295,8 @@ class AudioSeal:
     def load_generator(
         model_card_or_path: str,
         nbits: Optional[int] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
     ) -> AudioSealWM:
         """Load the AudioSeal generator from the model card"""
         checkpoint, config = AudioSeal.parse_model(
@@ -301,7 +305,7 @@ class AudioSeal:
             nbits=nbits,
         )
 
-        model = create_generator(config)
+        model = create_generator(config, device=device, dtype=dtype)
         _update_state_dict(model, checkpoint)
         return model
 
@@ -309,12 +313,14 @@ class AudioSeal:
     def load_detector(
         model_card_or_path: str,
         nbits: Optional[int] = None,
+        device: Optional[Device] = None,
+        dtype: Optional[DataType] = None,
     ) -> AudioSealDetector:
         checkpoint, config = AudioSeal.parse_model(
             model_card_or_path,
             AudioSealDetectorConfig,
             nbits=nbits,
         )
-        model = create_detector(config)
+        model = create_detector(config, device=device, dtype=dtype)
         _update_state_dict(model, checkpoint)
         return model

--- a/src/audioseal/models.py
+++ b/src/audioseal/models.py
@@ -192,7 +192,7 @@ class AudioSealDetector(torch.nn.Module):
             / result.shape[-1]
         )
         if x.shape[0] == 1:
-            detect_prob = detect_prob.detach().cpu().item()
+            detect_prob = detect_prob.detach().cpu().item()  # type: ignore
         message = torch.gt(message, message_threshold).int()
         return detect_prob, message
 

--- a/src/audioseal/models.py
+++ b/src/audioseal/models.py
@@ -117,7 +117,9 @@ class AudioSealWM(torch.nn.Module):
                 else:
                     message = self.message.to(device=x.device)
             else:
-                message = message.to(device=x.device)
+                if message.ndim == 1:
+                    message = message.unsqueeze(0).repeat(x.shape[0], 1)
+                message = message.to(device=x.device)   # type: ignore
 
             hidden = self.msg_processor(hidden, message)
 

--- a/src/audioseal/models.py
+++ b/src/audioseal/models.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import julius
 import torch
@@ -172,7 +172,7 @@ class AudioSealDetector(torch.nn.Module):
         sample_rate: Optional[int] = None,
         message_threshold: float = 0.5,
         detection_threshold: float = 0.5,
-    ) -> Tuple[float, torch.Tensor]:
+    ) -> Union[Tuple[float, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
         """
         A convenience function that returns a probability of an audio being watermarked,
         together with its message in n-bits (binary) format. If the audio is not watermarked,
@@ -191,6 +191,8 @@ class AudioSealDetector(torch.nn.Module):
             torch.count_nonzero(torch.gt(result[:, 1, :], detection_threshold), dim=-1)
             / result.shape[-1]
         )
+        if x.shape[0] == 1:
+            detect_prob = detect_prob.detach().cpu().item()
         message = torch.gt(message, message_threshold).int()
         return detect_prob, message
 


### PR DESCRIPTION
## Why ?

Update to 0.1.8 with some internal fixes ported to public repo:
- Fix for running the inference in case the message is provided externally and in batch mode
- Support sending the models to device and dtype at loading time to save memory
- Adding `detection_threshold` to `AudiosealDetector.detect_watermark()` function (currently hard-coded at 0.5)
