### PR TITLE
Add Meta copyright headers to moshi modules

### DIFF
--- a/src/audioseal/libs/moshi/modules/gating.py
+++ b/src/audioseal/libs/moshi/modules/gating.py
@@ -1,4 +1,7 @@
 # Copyright (c) Kyutai, all rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/src/audioseal/libs/moshi/modules/resample.py
+++ b/src/audioseal/libs/moshi/modules/resample.py
@@ -1,4 +1,7 @@
 # Copyright (c) Kyutai, all rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/src/audioseal/libs/moshi/modules/rope.py
+++ b/src/audioseal/libs/moshi/modules/rope.py
@@ -1,4 +1,7 @@
 # Copyright (c) Kyutai, all rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/src/audioseal/libs/moshi/modules/transformer.py
+++ b/src/audioseal/libs/moshi/modules/transformer.py
@@ -1,4 +1,7 @@
 # Copyright (c) Kyutai, all rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/src/audioseal/libs/moshi/utils/compile.py
+++ b/src/audioseal/libs/moshi/utils/compile.py
@@ -1,4 +1,7 @@
 # Copyright (c) Kyutai, all rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 


### PR DESCRIPTION
Preserves original Kyutai copyright attribution while adding Meta Platforms, Inc. copyright header to satisfy open source requirements.

Files updated:
- src/audioseal/libs/moshi/modules/gating.py
- src/audioseal/libs/moshi/modules/resample.py
- src/audioseal/libs/moshi/modules/rope.py
- src/audioseal/libs/moshi/modules/transformer.py
- src/audioseal/libs/moshi/utils/compile.py